### PR TITLE
Use hook banner instead of renderChunk

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ module.exports = function (options) {
             }
         },
 
-        renderChunk: async (code) => {
+        banner: async () => {
             let output = '';
             
             for (let key in cache) {
@@ -50,7 +50,7 @@ module.exports = function (options) {
                 });                
             }
 
-            return output + code;
+            return output;
         }
     }
 }


### PR DESCRIPTION
Async renderChunk is incompatible with rollup-plugin-typescript2 (see #1).

Using renderChunk a bit breaks behaviour of Rollup’s `output.banner` — the configured banner is rendered **after** the output of this plugin, instead of at the top of the generated file. Thus it disallows using `output.banner` to inject shebang into the generated file.